### PR TITLE
Add long_description for Pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
 from setuptools import setup
 
+ROOTDIR = path.abspath(path.dirname(__file__))
+with open(path.join(ROOTDIR, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
 setup(name='remind-caldav',
       version='0.7.0',
       description='''
        Remind CalDAV tools
        ''',
+      long_description=long_description,
+      long_description_content_type='text/x-rst',
       author='Jochen Sprickerhof',
       author_email='remind@jochen.sprickerhof.de',
       license='GPLv3+',


### PR DESCRIPTION
This would render the README.rst onto the [Pypi](https://pypi.org/project/remind-caldav/)
An example of this is the [setup.py](https://github.com/dumbPy/iitb-login/blob/master/setup.py)  of one of my simple projects, and it's [Pypi](https://pypi.org/project/iitb-login/) (though it is in markdown, and this project's readme is in [reStructured Text](https://packaging.python.org/specifications/core-metadata/#description-content-type))